### PR TITLE
Added a test for duplicate xml:id in results.

### DIFF
--- a/test/test_existdb/test_db.py
+++ b/test/test_existdb/test_db.py
@@ -53,6 +53,10 @@ class ExistDBTest(unittest.TestCase):
         self.test_groups = []
         self.test_users = []
 
+        xml = '<root xml:id="A"/>'
+        self.db.load(xml, self.COLLECTION + '/xqry_test3.xml', True)
+        self.db.load(xml, self.COLLECTION + '/xqry_test4.xml', True)
+
     def tearDown(self):
         self.db.removeCollection(self.COLLECTION)
 
@@ -191,7 +195,7 @@ class ExistDBTest(unittest.TestCase):
             "collection owner returned (expected '%s', got %s" % \
                 (EXISTDB_SERVER_USER, info['owner']))
         # untested - group, created, permissions
-        self.assertEqual(3, len(info['documents']), "collection has 3 documents (3 test documents loaded)")
+        self.assertEqual(5, len(info['documents']), "collection has 5 documents (5 test documents loaded)")
         self.assertEqual([], info['collections'], "collection has no subcollections")
 
         # attempting to describe a collection that isn't in the db
@@ -243,6 +247,17 @@ class ExistDBTest(unittest.TestCase):
         # xqry = u'collection("/db%s")//root[contains(unicode, "%s")]' % (self.COLLECTION, unicode_str)
         # qres = self.db.query(xqry)
         # self.assertEquals(qres.hits, 1)
+
+    def test_query_duplicate_ids(self):
+        """
+        Test xquery with duplicate IDs in result. A query that returns
+        multiple XML documents that have the same xml:id value
+        appearing in them should not result in a query failure.
+        """
+        xqry = 'for $x in collection("/db%s")//root[@xml:id] return $x' % (
+            self.COLLECTION, )
+        qres = self.db.query(xqry)
+        self.assertEquals(qres.hits, 2)
 
     def test_query_bad_xqry(self):
         """Check that an invalid xquery raises an exception"""


### PR DESCRIPTION
When eXist-db returns results from queries, the results are put in an exist:result element. Suppose that two elements in two valid XML documents stored in eXist have the same xml:id. This is fine because the elements are in different documents. Now if the a query is such that the two elements are part of the results, the resulting XML won't be valid because it will contain the same xml:id value twice. However, the XML will be well-formed. The added test checks that eulexistdb is able to return the well-formed results. (That is, it won't try to validate the result and raise a validation error.)

Note that this test won't pass until the changes provided in [this pull request](https://github.com/emory-libraries/eulxml/pull/29) are integrated in eulxml.